### PR TITLE
Treat blank CA Cert data as null

### DIFF
--- a/src/main/java/cd/go/contrib/secrets/kubernetes/models/SecretConfig.java
+++ b/src/main/java/cd/go/contrib/secrets/kubernetes/models/SecretConfig.java
@@ -61,7 +61,7 @@ public class SecretConfig {
     }
 
     public String getClusterCACertData() {
-        return clusterCACertData;
+        return clusterCACertData != null && clusterCACertData.isBlank() ? null : clusterCACertData;
     }
 
     public String getNamespace() {

--- a/src/test/java/cd/go/contrib/secrets/kubernetes/models/SecretConfigTest.java
+++ b/src/test/java/cd/go/contrib/secrets/kubernetes/models/SecretConfigTest.java
@@ -1,0 +1,22 @@
+package cd.go.contrib.secrets.kubernetes.models;
+
+import cd.go.plugin.base.GsonTransformer;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SecretConfigTest {
+
+    @Test
+    public void shouldConsiderBlankCertAsNull() {
+        final Map<String, Object> settings = new HashMap<>();
+        settings.put("kubernetes_cluster_ca_cert", "   ");
+
+        SecretConfig config = GsonTransformer.fromJson(GsonTransformer.toJson(settings), SecretConfig.class);
+
+        assertThat(config.getClusterCACertData()).isNull();
+    }
+}


### PR DESCRIPTION
The Kubernetes Client appears to treat these differently. If using a null cert it appears it willm either fall back to trusting all certs or (more likely) using an auto-configured cert it finds within the pod from the service account auto mount files.

Currently there are weird inconsistencies as after you edit the config or restart the server it can set an empty string which starts causing validation failures talking to the API.